### PR TITLE
Use query string to limit number of comments.

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -28,6 +28,8 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.FetchOptions;
 
 import com.google.gson.Gson;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +41,8 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    comments = getComments(5);
+    int numComments = getIntParameter(request, "num-comments");
+    comments = getComments(numComments);
 
     Gson gson = new Gson();
     response.setContentType("application/json;");
@@ -51,6 +54,21 @@ public class DataServlet extends HttpServlet {
     String commentText = request.getParameter("comment-text");
     addNewComment(commentText);
     response.sendRedirect("/index.html");
+  }
+
+  /**
+   * Helper function to get and attempt to parse an integer parameter in request's query string.
+   */
+  private int getIntParameter(HttpServletRequest request, String param) {
+    String numberString = request.getParameter(param);
+
+    try {
+      int number = Integer.parseInt(numberString);
+      return number;
+    } catch (Exception e) {
+      System.err.println("Could not convert to int: " + numberString);
+      return -1;
+    }
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -74,7 +74,7 @@ public class DataServlet extends HttpServlet {
   /**
    * Helper function that returns an ArrayList of strings 
    * with `numComments` of the comments in Datastore.
-   * All comments will be loaded if numComments < 0
+   * All comments will be loaded if numComments < 0 or null.
    */
   private ArrayList<String> getComments(Integer numComments) {
     ArrayList<String> comments = new ArrayList<String>();

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -41,7 +41,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    int numComments = getIntParameter(request, "num-comments");
+    Integer numComments = getIntParameter(request, "num-comments");
     comments = getComments(numComments);
 
     Gson gson = new Gson();
@@ -59,7 +59,7 @@ public class DataServlet extends HttpServlet {
   /**
    * Helper function to get and attempt to parse an integer parameter in request's query string.
    */
-  private int getIntParameter(HttpServletRequest request, String param) {
+  private Integer getIntParameter(HttpServletRequest request, String param) {
     String numberString = request.getParameter(param);
 
     try {
@@ -67,7 +67,7 @@ public class DataServlet extends HttpServlet {
       return number;
     } catch (Exception e) {
       System.err.println("Could not convert to int: " + numberString);
-      return -1;
+      return null;
     }
   }
 
@@ -76,9 +76,9 @@ public class DataServlet extends HttpServlet {
    * with `numComments` of the comments in Datastore.
    * All comments will be loaded if numComments < 0
    */
-  private ArrayList<String> getComments(int numComments) {
+  private ArrayList<String> getComments(Integer numComments) {
     ArrayList<String> comments = new ArrayList<String>();
-    if (numComments < 0) numComments = Integer.MAX_VALUE;
+    if (numComments ==  null) numComments = Integer.MAX_VALUE;
 
     Query query = new Query("Comment");
     List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withLimit(numComments));

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -25,9 +25,11 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.FetchOptions;
 
 import com.google.gson.Gson;
 import java.util.ArrayList;
+import java.util.List;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
@@ -37,7 +39,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    comments = getComments();
+    comments = getComments(5);
 
     Gson gson = new Gson();
     response.setContentType("application/json;");
@@ -52,15 +54,16 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Helper function that returns an Array of strings with all the comments in Datastore
+   * Helper function that returns an Array of strings with numComments of the comments in Datastore.
+   * (TODO: All comments will be loaded if numComments === -1)
    */
-  private ArrayList<String> getComments() {
+  private ArrayList<String> getComments(int numComments) {
     ArrayList<String> comments = new ArrayList<String>();
 
     Query query = new Query("Comment");
-    PreparedQuery results = datastore.prepare(query);
+    List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withLimit(numComments));
 
-    for (Entity entity : results.asIterable()) {
+    for (Entity entity : results) {
       comments.add((String) entity.getProperty("text"));
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -54,11 +54,13 @@ public class DataServlet extends HttpServlet {
   }
 
   /**
-   * Helper function that returns an Array of strings with numComments of the comments in Datastore.
-   * (TODO: All comments will be loaded if numComments === -1)
+   * Helper function that returns an ArrayList of strings 
+   * with `numComments` of the comments in Datastore.
+   * All comments will be loaded if numComments < 0
    */
   private ArrayList<String> getComments(int numComments) {
     ArrayList<String> comments = new ArrayList<String>();
+    if (numComments < 0) numComments = Integer.MAX_VALUE;
 
     Query query = new Query("Comment");
     List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withLimit(numComments));

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -78,7 +78,7 @@ public class DataServlet extends HttpServlet {
    */
   private ArrayList<String> getComments(Integer numComments) {
     ArrayList<String> comments = new ArrayList<String>();
-    if (numComments ==  null) numComments = Integer.MAX_VALUE;
+    if (numComments ==  null || numComments < 0) numComments = Integer.MAX_VALUE;
 
     Query query = new Query("Comment");
     List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withLimit(numComments));

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
+/** Servlet that returns some comments content.*/
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   private ArrayList<String> comments;
@@ -63,8 +63,7 @@ public class DataServlet extends HttpServlet {
     String numberString = request.getParameter(param);
 
     try {
-      int number = Integer.parseInt(numberString);
-      return number;
+      return Integer.parseInt(numberString);
     } catch (Exception e) {
       System.err.println("Could not convert to int: " + numberString);
       return null;
@@ -100,3 +99,4 @@ public class DataServlet extends HttpServlet {
     datastore.put(commentEntity);
   }
 }
+

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -27,7 +27,8 @@
     </div>
     <div id="comments">
       <label for="num-comments">Number of Comments:</label>
-      <input type="number" name="num-comments" id="num-comments" min="0" value="10"/>
+      <input type="number" name="num-comments" id="num-comments" 
+        min="0" value="10" onchange="loadComments()"/>
 
       <ul id="comments-list"></ul>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -24,8 +24,13 @@
       <p>Click here to get a random message:</p>
       <button onclick="addRandomGreeting()">Hello</button>
       <div id="greeting-container"></div>
+    </div>
+    <div id="comments">
+      <label for="num-comments">Number of Comments:</label>
+      <input type="number" name="num-comments" id="num-comments" min="0" value="10"/>
 
       <ul id="comments-list"></ul>
+
       <form action="/data" method="POST">
         <textarea name="comment-text" placeholder="Enter a comment"></textarea>
         <input type="submit"/>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -71,7 +71,7 @@ function onBodyLoad() {
  */
 function loadComments() {
   clearComments();
-  let numComments = document.getElementById("num-comments")?.getAttribute("value");
+  let numComments = document.getElementById("num-comments")?.value;
 
   fetch("/data?num-comments=" + numComments).then(response => response.json()).then(comments => {
     const commentsEl = document.getElementById("comments-list");
@@ -88,6 +88,5 @@ function loadComments() {
  */
 function clearComments() {
   const commentsEl = document.getElementById("comments-list");
-  if (commentsEl)
-    commentsEl.innerHTML = "";
+  if (commentsEl) commentsEl.innerHTML = "";
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -66,10 +66,13 @@ function onBodyLoad() {
 }
 
 /**
- * Fetch comments array from the server and load them to the list of comments, if it exists.
+ * Clear comments, then fetch them from the server and 
+ * load them to the list of comments, if it exists.
  */
 function loadComments() {
-  let numComments = "3"
+  clearComments();
+  let numComments = document.getElementById("num-comments")?.getAttribute("value");
+
   fetch("/data?num-comments=" + numComments).then(response => response.json()).then(comments => {
     const commentsEl = document.getElementById("comments-list");
     comments.forEach(comment => {
@@ -78,4 +81,13 @@ function loadComments() {
       commentsEl?.appendChild(liElement);
     });
   });
+}
+
+/**
+ * Clear comments from comments list.
+ */
+function clearComments() {
+  const commentsEl = document.getElementById("comments-list");
+  if (commentsEl)
+    commentsEl.innerHTML = "";
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -69,7 +69,8 @@ function onBodyLoad() {
  * Fetch comments array from the server and load them to the list of comments, if it exists.
  */
 function loadComments() {
-  fetch("/data").then(response => response.json()).then(comments => {
+  let numComments = "3"
+  fetch("/data?num-comments=" + numComments).then(response => response.json()).then(comments => {
     const commentsEl = document.getElementById("comments-list");
     comments.forEach(comment => {
       const liElement = document.createElement('li');

--- a/portfolio/src/main/webapp/templates/footer.html
+++ b/portfolio/src/main/webapp/templates/footer.html
@@ -1,4 +1,5 @@
 <footer>
+  <hr/>
   <a href="https://github.com/andres-holguin"><img src="/images/icons/GitHub-Logo.png"/></a>
   <a href="https://www.linkedin.com/in/andres-d-holguin/"><img src="/images/icons/LinkedIn-Logo.svg"/></a>
 </footer>

--- a/portfolio/src/main/webapp/templates/header.html
+++ b/portfolio/src/main/webapp/templates/header.html
@@ -11,4 +11,5 @@
     <a href="/projects.html">Projects</a> |
     <a href="/gallery.html">Gallery</a>
   </nav>
+  <hr/>
 </header>


### PR DESCRIPTION
Use the query string in the Request to limit the number of comments retrieved from Datastore.

I wasn't sure if getIntParameter() should return -1 or null. It currently returns null but I've heard that may be bad practice. Any suggestions?