### PR TITLE
Add implementation to handle optional attendees in meeting request.

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,27 +21,63 @@ import java.util.ArrayList;
 
 public final class FindMeetingQuery {
 
-  /** return possible times everyone can meet by removing all minutes already scheduled */
+  /** 
+   * Return possible times everyone can meet by removing all minutes already scheduled. 
+   * If optional attendees can all be included, those times will be returned instead.
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    ArrayList<TimeRange> timeRanges = new ArrayList<>();
     final int MINUTES_IN_DAY = 60 * 24;
 
-    // Initialize boolean array for each minutes in the day
-    boolean[] availableMinutes = new boolean[MINUTES_IN_DAY + 1];
-    Arrays.fill(availableMinutes, true);  
+    ArrayList<TimeRange> timeRanges = new ArrayList<>();
 
+    // If a meeting can be scheduled while considering optional attendees, those times will be returned instead
+    ArrayList<TimeRange> timeRangesWithOptionalAttendees = new ArrayList<>();
+
+    // Initialize boolean arrays for each minute in the day.
+    boolean[] availableMinutes = new boolean[MINUTES_IN_DAY + 1];
+    Arrays.fill(availableMinutes, true);
+    boolean[] availableMinutesWithOptionalAttendees = new boolean[MINUTES_IN_DAY + 1];
+    Arrays.fill(availableMinutesWithOptionalAttendees, true);
+
+    
     // For each event with matching attending, remove respective available minutes
     for (Event event : events) {
-      // Skip if attendees don't overlap
-      if (Collections.disjoint(event.getAttendees(), request.getAttendees())) continue;
-      // Someone in the meeting request has another event, so remove those available minutes
-      TimeRange eventTime = event.getWhen();
-      for (int i = eventTime.start(); i < eventTime.end(); i++) {
-        availableMinutes[i] = false;
+      if (!Collections.disjoint(event.getAttendees(), request.getAttendees())) {
+        // If the event and request attendees have an overlap (not disjoint),
+        // Someone in the meeting request has another event, so remove those available minutes
+        TimeRange eventTime = event.getWhen();
+        for (int i = eventTime.start(); i < eventTime.end(); i++) {
+          availableMinutes[i] = false;
+          availableMinutesWithOptionalAttendees[i] = false;
+        }
       }
+      if (!Collections.disjoint(event.getAttendees(), request.getOptionalAttendees())) {
+        // Same as above, but only considers optional attendees.
+        TimeRange eventTime = event.getWhen();
+        for (int i = eventTime.start(); i < eventTime.end(); i++) {
+          availableMinutesWithOptionalAttendees[i] = false;
+          // If there are no mandatory attendees, optional attendees should be treated as mandatory.
+          if (request.getAttendees().isEmpty()) availableMinutes[i] = false;
+        }
+      }      
     }
 
-    // Build Time Ranges from boolean array
+    // Build Time Ranges from boolean arrays
+    buildTimeRanges(timeRangesWithOptionalAttendees, availableMinutesWithOptionalAttendees, request.getDuration());
+    if (!timeRangesWithOptionalAttendees.isEmpty()) {
+      return timeRangesWithOptionalAttendees;
+    } else {
+      buildTimeRanges(timeRanges, availableMinutes, request.getDuration());
+      return timeRanges;
+    }
+  }
+
+  /**
+   * Fill the list of Time Ranges ( @param timeRanges ) with options for times to schedule 
+   * based on the array of available minutes ( @param availableMinutes ) and the duration of
+   * the requested meeting ( @param requestDuration ).
+   */
+  private void buildTimeRanges(ArrayList<TimeRange> timeRanges, boolean[] availableMinutes, long requestDuration) {
     boolean lastMinuteAvailable = false;
     int start = 1, end = 0;
     for (int i = 0; i < availableMinutes.length; i++) {
@@ -54,13 +90,11 @@ public final class FindMeetingQuery {
       if (lastMinuteAvailable && (!currentMinuteAvailable || onLastIteration)) { 
         // The end of a potential time range, or the end of the boolean array
         end = i;
-        if (end - start >= request.getDuration()) {
+        if (end - start >= requestDuration) {
           timeRanges.add(TimeRange.fromStartEnd(start, end, false));
         }
       }
       lastMinuteAvailable = currentMinuteAvailable;
     }
-
-    return timeRanges;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,10 +34,12 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
@@ -270,5 +272,130 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-}
 
+  @Test
+  public void optionalAttendeeBusyAllDay() {
+    // Consider two mandatory attendees with different events.
+    // Add an optional attendee C who has an all-day event.
+    // Should expect same result as everyAttendeeIsConsidered.
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY,
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+  
+  @Test
+  public void optionalAttendeeSplitsRestriction() {
+    // Consider two mandatory attendees with different events.
+    // Add an optional attendee C who has an event during one of the Time Ranges for mandatory attendees.
+    // Should expect only the early and late parts of everyAttendeeIsConsidered.
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomWithoutOptionalAttendee() {
+    // Have just enough room for the mandatory attendee, but considering the optional
+    // attendee causes the opening to be too short. The optional attendee is then ignored.
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, false),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesAndAllConsidered() {
+    // Only two optional attendees with different events.
+    // The gaps in their events should be returned.
+    // Events  :       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithNoRoom() {
+    // Only two optional attendees with different events that have no gaps.
+    // Should expect that no time is available
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.WHOLE_DAY,
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.WHOLE_DAY,
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Use test-driven development to create tests for when optional attendees are included in the meeting request. Then modify the query handler to pass all tests. In general, this involved creating a second list of possible times to meet where optional attendees are considered required. If that list is not empty, it is returned instead of the one that only considers required attendees.